### PR TITLE
Adds registeredAt/By to exclude list for new AWS CLI

### DIFF
--- a/app/Commands/DeployEcsServiceUpdate.php
+++ b/app/Commands/DeployEcsServiceUpdate.php
@@ -154,11 +154,19 @@ class DeployEcsServiceUpdate extends Command
     protected function prepareTaskDefinitionForRegister($taskDefinition): string
     {
         // ECS does not want any of this back
-        unset($taskDefinition['taskDefinition']['taskDefinitionArn']);
-        unset($taskDefinition['taskDefinition']['revision']);
-        unset($taskDefinition['taskDefinition']['status']);
-        unset($taskDefinition['taskDefinition']['requiresAttributes']);
-        unset($taskDefinition['taskDefinition']['compatibilities']);
+        $excludeKeys = [
+            'taskDefinitionArn',
+            'revision',
+            'status',
+            'requiresAttributes',
+            'compatibilities',
+            'registeredAt',
+            'registeredBy',
+        ];
+
+        foreach ($excludeKeys as $key) {
+            unset($taskDefinition['taskDefinition'][$key]);
+        }
 
         return json_encode($taskDefinition['taskDefinition']);
     }


### PR DESCRIPTION
The new AWS CLI returns registeredAt/registeredBy (must be using a new iteration of the AWS API). This causes ECS to throw a wobbly when we send it back, fix was to simply add it to the array of items to remove.