### PR TITLE
Adds ssm:copy command to allow for scp over ssm

### DIFF
--- a/app/Commands/AwsSsmConnect.php
+++ b/app/Commands/AwsSsmConnect.php
@@ -137,7 +137,7 @@ class AwsSsmConnect extends BaseCommand
     {
         $this->info("You can run this command again without having to go through options using this:");
         $this->info(' ');
-        $this->comment("netsells aws:ssm:connect " . implode(' ', $rebuildOptions));
+        $this->comment("netsells " . $this->signature . " " . implode(' ', $rebuildOptions));
         $this->info(' ');
     }
 
@@ -189,7 +189,7 @@ class AwsSsmConnect extends BaseCommand
         return $this->menu("Choose an instance to connect to...", $instances->toArray())->open();
     }
 
-    private function generateTempSshKey()
+    protected function generateTempSshKey()
     {
         $requiredBinaries = ['aws', 'ssh', 'ssh-keygen'];
 
@@ -227,7 +227,7 @@ class AwsSsmConnect extends BaseCommand
         return trim(file_get_contents($pubKeyName));
     }
 
-    private function generateRemoteCommand($username, $key)
+    protected function generateRemoteCommand($username, $key)
     {
         // Borrowed from https://github.com/elpy1/ssh-over-ssm/blob/master/ssh-ssm.sh#L10
         return trim(<<<EOF

--- a/app/Commands/AwsSsmCopy.php
+++ b/app/Commands/AwsSsmCopy.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace App\Commands;
+
+use App\Exceptions\ProcessFailed;
+use Symfony\Component\Process\Process;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class AwsSsmCopy extends AwsSsmConnect
+{
+    /**
+     * The signature of the command.
+     *
+     * @var string
+     */
+    protected $signature = 'aws:ssm:copy';
+
+    /**
+     * The description of the command.
+     *
+     * @var string
+     */
+    protected $description = 'Copy files from/to a server over SSM';
+
+    public function configure()
+    {
+        $this->setDefinition(array_merge([
+            new InputOption('instance-id', null, InputOption::VALUE_OPTIONAL, 'The instance ID to connect to'),
+            new InputOption('username', null, InputOption::VALUE_OPTIONAL, 'The username connect with'),
+            new InputOption('direction', null, InputOption::VALUE_OPTIONAL, 'Direction (Up/Down)'),
+            new InputOption('local-path', null, InputOption::VALUE_OPTIONAL, 'The path of the other server (local or remote). Can be a file or folder'),
+            new InputOption('remote-path', null, InputOption::VALUE_OPTIONAL, 'The path of the server. Can be a file or folder'),
+            new InputOption('other-server', null, InputOption::VALUE_OPTIONAL, 'Left blank, the other server is the local machine. Otherwise, specify user@host'),
+        ], $this->helpers->aws()->commonConsoleOptions()));
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $requiredBinaries = ['aws', 'ssh'];
+
+        if ($this->helpers->checks()->checkAndReportMissingBinaries($requiredBinaries)) {
+            return 1;
+        }
+
+        $rebuildOptions = [];
+
+        $instanceId = $this->option('instance-id') ?: $this->askForInstanceId();
+        $username = $this->option('username') ?: $this->askForUsername();
+
+        if (!$instanceId) {
+            $this->error('No instance ID provided.');
+            return 1;
+        }
+
+        $rebuildOptions = $this->appendResolvedArgument($rebuildOptions, 'username', $username);
+        $rebuildOptions = $this->appendResolvedArgument($rebuildOptions, 'instance-id', $instanceId);
+        $rebuildOptions = $this->appendResolvedArgument($rebuildOptions, 'aws-profile');
+        $rebuildOptions = $this->appendResolvedArgument($rebuildOptions, 'aws-region');
+
+        $key = $this->generateTempSshKey();
+        $command = $this->generateRemoteCommand($username, $key);
+
+        $this->info("Sending a temporary SSH key to the server...", OutputInterface::VERBOSITY_VERBOSE);
+        if (!$this->helpers->aws()->ssm()->sendRemoteCommand($instanceId, $command)) {
+            $this->error('Failed to send SSH key to server');
+            return 1;
+        }
+
+        $sessionCommand = $this->helpers->aws()->ssm()->startSessionProcess($instanceId);
+        $sessionCommandString = implode(' ', $sessionCommand->getArguments());
+
+        $options = [
+            '-o', 'IdentityFile ~/.ssh/netsells-cli-ssm-ssh-tmp',
+            '-o', 'IdentitiesOnly yes',
+            '-o', 'GSSAPIAuthentication no',
+            '-o', 'PasswordAuthentication no',
+            '-o', "ProxyCommand {$sessionCommandString}",
+        ];
+
+        $direction = trim($this->option('direction')) ?: $this->askForDirection();
+
+        if (!$this->validateDirection($direction)) {
+            $this->error('Invalid direction');
+        }
+
+        $rebuildOptions = $this->appendResolvedArgument($rebuildOptions, 'direction', $direction);
+
+        $otherServer = trim($this->option('other-server')) ?: $this->askForOtherServer();
+
+        $localPath = trim($this->option('local-path')) ?: $this->askForLocalPath($otherServer);
+        $remotePath = trim($this->option('remote-path')) ?: $this->askForRemotePath();
+
+        $rebuildOptions = $this->appendResolvedArgument($rebuildOptions, 'local-path', $localPath);
+        $rebuildOptions = $this->appendResolvedArgument($rebuildOptions, 'remote-path', $remotePath);
+        $rebuildOptions = $this->appendResolvedArgument($rebuildOptions, 'other-server', $otherServer);
+
+        $this->sendReRunHelper($rebuildOptions);
+
+        $localOption = ($otherServer !== '__localhost__' ? "{$otherServer}:" : null) . $localPath;
+        $remoteOption = sprintf("%s@%s", $username, $instanceId) . ":{$remotePath}";
+
+        $directionOptions = ($direction == 'up') ? [$localOption, $remoteOption] : [$remoteOption, $localOption];
+
+        try {
+            $this->helpers->process()->withCommand(array_merge(
+                [
+                    'scp',
+                ],
+                $options,
+                $directionOptions,
+            ))
+            ->withTimeout(null)
+            ->withProcessModifications(function ($process) {
+                $process->setTty(Process::isTtySupported());
+                $process->setIdleTimeout(null);
+            })
+            ->run();
+        } catch (ProcessFailed $e) {
+            $this->info(' ');
+            $this->error("SCP command exited with an exit code of " . $e->getCode());
+        }
+    }
+
+    protected function askForDirection()
+    {
+        return $this->menu("Which direction are you sending the files?", [
+            'up' => 'Upstream',
+            'down' => 'Downstream',
+        ])->open();
+    }
+
+    protected function validateDirection($direction): bool
+    {
+        return in_array($direction, ['up', 'down']);
+    }
+
+    protected function askForLocalPath($otherServer)
+    {
+        if ($otherServer == '__localhost__') {
+            return $this->ask("What is the path of the file/folder on your computer?");
+        }
+
+        return $this->ask("What is the path of the file/folder on the other server? ({$otherServer})");
+    }
+
+    protected function askForRemotePath()
+    {
+        return $this->ask("What is the path of the file/folder on the remote server?");
+    }
+
+    protected function askForOtherServer()
+    {
+        return $this->ask("What is the path of the other server? Should be in the format username@hostname. Leave blank for this computer", '__localhost__');
+    }
+}

--- a/app/Commands/Console/InputOption.php
+++ b/app/Commands/Console/InputOption.php
@@ -23,7 +23,7 @@ class InputOption extends BaseInputOption
         $constantName = sprintf("%s::%s", NetsellsFile::class, $this->netsellsFilePrefix . $keyName);
 
         if (defined($constantName)) {
-            return (new NetsellsFile())->get(constant($constantName));
+            return (new NetsellsFile())->get(constant($constantName), parent::getDefault());
         }
 
         return parent::getDefault();

--- a/app/Helpers/Aws/Ec2.php
+++ b/app/Helpers/Aws/Ec2.php
@@ -31,7 +31,7 @@ class Ec2
             $processOutput = $this->aws->newProcess($commandOptions)
             ->run();
         } catch (ProcessFailed $e) {
-            $this->command->error("Unable to list ec2 instances");
+            $this->aws->getCommand()->error("Unable to list ec2 instances");
             return null;
         }
 


### PR DESCRIPTION
Needed for a few times to do a scp over SSM.

Added a command that takes 90% of stuff from the ssm command and allows for a copy interface of either direction. Also allows for a copy from another server to the SSM server.

This is the first pass so go easy :D

I'm not *super* happy with the `__localhost__` hack, but I needed a non null value to that the rebuild option had a value to prevent it being asked every time - thoughts?