### PR TITLE
Fixes for MFA login and env issues

### DIFF
--- a/app/Commands/AwsAssumeRole.php
+++ b/app/Commands/AwsAssumeRole.php
@@ -92,7 +92,7 @@ class AwsAssumeRole extends BaseCommand
 
         $this->info("Now opening a session following you ({$sessionUser}) assuming the role {$role} on {$accountName} ({$accountId}) . Type `exit` to leave this shell.");
 
-        (new Process([config('app.shell')]))
+        (new Process([env('SHELL', 'bash')]))
             ->setEnv(array_merge($envVars, [
                 'AWS_S3_ENV' => $account['s3env'],
                 'BASH_SILENCE_DEPRECATION_WARNING' => '1',

--- a/app/Commands/AwsMfaLogin.php
+++ b/app/Commands/AwsMfaLogin.php
@@ -50,6 +50,11 @@ class AwsMfaLogin extends BaseCommand
 
         $envVars = $this->helpers->aws()->iam()->authenticateWithMfaDevice($mfaDevice, $code);
 
+        if (empty($envVars)) {
+            $this->error("Unable to authenicate MFA");
+            return 1;
+        }
+
         $this->info("Now opening a session following your MFA authentication. Type `exit` to leave this shell.");
 
         (new Process([config('app.shell')]))

--- a/app/Commands/AwsMfaLogin.php
+++ b/app/Commands/AwsMfaLogin.php
@@ -57,7 +57,7 @@ class AwsMfaLogin extends BaseCommand
 
         $this->info("Now opening a session following your MFA authentication. Type `exit` to leave this shell.");
 
-        (new Process([config('app.shell')]))
+        (new Process([env('SHELL', 'bash')]))
             ->setEnv(array_merge($envVars, [
                 'BASH_SILENCE_DEPRECATION_WARNING' => '1',
                 'PS1' => "\e[32mnscli\e[34m(mfa-authd)$\e[39m ",

--- a/app/Commands/EditEnvironmentVariables.php
+++ b/app/Commands/EditEnvironmentVariables.php
@@ -36,6 +36,8 @@ class EditEnvironmentVariables extends BaseCommand
 
     private string $fileContents;
 
+    private string $editor;
+
     public function configure()
     {
         $this->setDefinition(array_merge([
@@ -50,7 +52,9 @@ class EditEnvironmentVariables extends BaseCommand
      */
     public function handle()
     {
-        $requiredBinaries = ['aws', config('app.editor')];
+        $this->editor = env('EDITOR', '/usr/bin/vi');
+
+        $requiredBinaries = ['aws', $this->editor];
 
         if ($this->helpers->checks()->checkAndReportMissingBinaries($requiredBinaries)) {
             exit(1);
@@ -143,7 +147,7 @@ class EditEnvironmentVariables extends BaseCommand
             case -1:
                 die('Unable to run editor');
             case 0:
-                pcntl_exec(config('app.editor'), ['/tmp/' . $this->fileName]);
+                pcntl_exec($this->editor, ['/tmp/' . $this->fileName]);
                 break;
             default:
                 pcntl_waitpid($pid, $status);

--- a/app/Helpers/Aws/Iam.php
+++ b/app/Helpers/Aws/Iam.php
@@ -59,14 +59,18 @@ class Iam
         ];
 
         try {
-            $processOutput = $this->aws->newProcess($commandOptions)
-            ->run();
+            $processOutput = $this->aws->newProcess($commandOptions)->run();
         } catch (ProcessFailed $e) {
-            $this->command->error("Unable to authenicate MFA");
-            return null;
+            return [];
         }
 
-        return json_decode($processOutput, true);
+        $result = json_decode($processOutput, true);
+
+        return [
+            'AWS_ACCESS_KEY_ID' => $result['Credentials']['AccessKeyId'],
+            'AWS_SECRET_ACCESS_KEY' => $result['Credentials']['SecretAccessKey'],
+            'AWS_SESSION_TOKEN' => $result['Credentials']['SessionToken'],
+        ];
     }
 
     public function assumeRole(int $accountId, string $role, string $sessionUser, ?string $mfaDevice = null, ?string $mfaCode = null): array

--- a/config/app.php
+++ b/config/app.php
@@ -56,7 +56,4 @@ return [
     'providers' => [
         App\Providers\AppServiceProvider::class,
     ],
-
-    'editor' => env('EDITOR', '/usr/bin/vi'),
-    'shell' => env('SHELL', 'bash')
 ];


### PR DESCRIPTION
## Overview
- [x] I have performed a self review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added sufficient logging
<!-- Remove the below if this project doesn't have tests (maybe it should?) -->
- [ ] New and existing tests pass locally with my changes
- [ ] The code modified as part of this PR has been covered with tests

### Problem statement
- MFA Login command was broken as it never parsed the output STS output into env variables
- The commands relying on EDITOR and SHELL environment variables always used the defaults, even when the environment variables existed at runtime

### Solution
- Parse the STS command output and return as array of env variables to fix the MFA Login command
- Read the EDITOR and SHELL from env at runtime, rather than setting it in config. Declaring them in config will hardcode whatever that's set to in the build environment, rather than reading from runtime.

### Dependencies
<!-- Other PRs that this PR depends on -->

### Test procedures
<!-- Step by step guide for testing this PR -->

### Links

JIRA: https://netsells.atlassian.net/browse/<!--JIRAID-->

## Deployment

### Migrations
Yes/No

### Environment variables
<!-- A list of any new/changed environment variables and where to find the correct value -->
<!-- Don't put keys in here. Place them in 1password or Slack -->

### Deployment notes
<!-- Any additional notes about deployment, such as one-off artisan commands that should be run or new cron jobs -->
