### PR TITLE
Edit Env Command: ask user for the S3 bucket if it's not provided otherwise.

### DIFF
--- a/app/Helpers/Aws/S3.php
+++ b/app/Helpers/Aws/S3.php
@@ -5,7 +5,6 @@ namespace App\Helpers\Aws;
 use App\Helpers\Aws;
 use Aws\Result;
 use Aws\S3\S3Client;
-use LaravelZero\Framework\Commands\Command;
 
 class S3
 {
@@ -15,6 +14,18 @@ class S3
     public function __construct(Aws $aws)
     {
         $this->aws = $aws;
+    }
+
+    /**
+     * Returns a list of bucket names available to the current user.
+     *
+     * @return string[] a list of bucket names
+     */
+    public function listBuckets(): array
+    {
+        $client = new S3Client($this->aws->standardSdkArguments());
+
+        return array_column($client->listBuckets()->get('Buckets') ?? [], 'Name');
     }
 
     public function listFiles(string $bucketName): ?array


### PR DESCRIPTION
## Overview
- [x] I have performed a self review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added sufficient logging
<!-- Remove the below if this project doesn't have tests (maybe it should?) -->
- [ ] New and existing tests pass locally with my changes
- [ ] The code modified as part of this PR has been covered with tests

### Problem statement
Some projects have multiple env buckets in a single AWS account. When that happens, we don't define a single bucket in the metadata, which means that to edit files in those buckets, we need to firstly run `aws s3 ls` and then explicitly provide the bucket option to the command.

### Solution
Uses existing mechanism to resolve bucket, but if that fails, it will fall back to bucket selection menu.

### Dependencies
<!-- Other PRs that this PR depends on -->

### Test procedures
<!-- Step by step guide for testing this PR -->

### Links

JIRA: https://netsells.atlassian.net/browse/OPTINT-25

## Deployment

### Migrations
Yes/No

### Environment variables
<!-- A list of any new/changed environment variables and where to find the correct value -->
<!-- Don't put keys in here. Place them in 1password or Slack -->

### Deployment notes
<!-- Any additional notes about deployment, such as one-off artisan commands that should be run or new cron jobs -->
